### PR TITLE
Added support for robotiq grippers

### DIFF
--- a/rox_bringup/configs/robotiq/robotiq_control.launch.py
+++ b/rox_bringup/configs/robotiq/robotiq_control.launch.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2022 PickNik, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Contributors: Pradheep Padmanabhan, Adarsh Karan K P
+
+import launch
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
+from launch.conditions import UnlessCondition
+import launch_ros
+import os
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    description_pkg_share = launch_ros.substitutions.FindPackageShare(
+        package="robotiq_description"
+    ).find("robotiq_description")
+
+    default_model_path = os.path.join(
+        description_pkg_share, "urdf", "robotiq_2f_140_gripper.urdf.xacro"
+    )
+
+    args = []
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="model",
+            default_value=default_model_path,
+            description="Absolute path to gripper URDF file",
+        )
+    )
+
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="use_mock_hardware",
+            default_value="false",
+            description="Mock gripper",
+        )
+    )
+
+    default_robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            LaunchConfiguration("model"),
+            " ",
+            "use_mock_hardware:=",
+            LaunchConfiguration("use_mock_hardware"),
+            " ",
+            "mock_sensor_commands:=",
+            LaunchConfiguration("use_mock_hardware"),
+        ]
+    )
+
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="robot_description_content",
+            default_value=default_robot_description_content,
+            description="Robot description XML content",
+        )
+    )
+
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="controllers_file",
+            default_value="robotiq_2f_140_controllers.yaml",
+            description="Gripper controllers file name",
+        )
+    )
+
+    robot_description_param = {
+        "robot_description": ParameterValue(
+            LaunchConfiguration("robot_description_content"), value_type=str
+        )
+    }
+
+    robot_state_pub_node = launch_ros.actions.Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[robot_description_param],
+        namespace="robotiq_gripper",
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static'),
+        ],
+    )
+
+    controllers_file = LaunchConfiguration("controllers_file")
+    initial_joint_controllers = ParameterFile(
+        PathJoinSubstitution([
+            FindPackageShare("robotiq_description"),
+            "config",
+            controllers_file
+        ]),
+        allow_substs=True
+    )
+
+    control_node = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        namespace="robotiq_gripper",
+        parameters=[
+            initial_joint_controllers,
+        ],
+        remappings=[
+            ('/robotiq_gripper/robot_description', 'robot_description'),
+            ('/robotiq_gripper/joint_states','/joint_states'),
+            ('/robotiq_gripper/dynamic_joint_states','/dynamic_joint_states'),
+        ],
+    )
+
+    joint_state_broadcaster_spawner = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace="robotiq_gripper",
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager",
+            "controller_manager",
+        ],
+        output="screen",
+    )
+
+    robotiq_gripper_controller_spawner = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace="robotiq_gripper",
+        arguments=["robotiq_gripper_controller", "-c", 
+            "controller_manager"]
+    )
+
+    robotiq_activation_controller_spawner = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace="robotiq_gripper",
+        arguments=["robotiq_activation_controller", "-c", 
+            "controller_manager"],
+        condition=UnlessCondition(
+            LaunchConfiguration("use_mock_hardware"),
+        ),
+    )
+
+    nodes = [
+        control_node,
+        robot_state_pub_node,
+        joint_state_broadcaster_spawner,
+        robotiq_gripper_controller_spawner,
+        robotiq_activation_controller_spawner,
+    ]
+
+    return launch.LaunchDescription(args + nodes)

--- a/rox_bringup/configs/robotiq/robotiq_epick_control.launch.py
+++ b/rox_bringup/configs/robotiq/robotiq_epick_control.launch.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2022 PickNik, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import launch
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
+from launch.conditions import IfCondition
+from ament_index_python.packages import get_package_share_directory
+import launch_ros
+import os
+
+def generate_launch_description():
+    description_pkg_share = launch_ros.substitutions.FindPackageShare(
+        package="epick_description"
+    ).find("epick_description")
+    default_model_path = os.path.join(
+        description_pkg_share, "urdf", "example.urdf.xacro"
+    )
+
+    args = []
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="model",
+            default_value=default_model_path,
+            description="Absolute path to gripper URDF file",
+        )
+    )
+
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="use_fake_hardware",
+            default_value="false",
+            description="Mock gripper",
+        )
+    )
+
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            LaunchConfiguration("model"),
+            " ",
+            "use_fake_hardware:=",
+            LaunchConfiguration("use_fake_hardware")
+        ]
+    )
+    robot_description_param = {
+        "robot_description": launch_ros.parameter_descriptions.ParameterValue(
+            robot_description_content, value_type=str
+        )
+    }
+
+    controllers_file = "controllers.yaml"
+    initial_joint_controllers = os.path.join(get_package_share_directory("epick_description"), 'config', controllers_file)
+
+    control_node = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        namespace="robotiq_epick_gripper",
+        parameters=[
+            robot_description_param,
+            initial_joint_controllers,
+        ],
+    )
+
+    # This is a controller for the Robotiq Epick gripper.
+    # epick_activation_controller_spawner = launch_ros.actions.Node(
+    #     package="controller_manager",
+    #     executable="spawner",
+    #     namespace="robotiq_epick_gripper",
+    #     arguments=["epick_gripper_action_controller", "-c", "controller_manager"],
+    # )
+
+    epick_status_controller_spawner = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace="robotiq_epick_gripper",
+        arguments=["epick_status_publisher_controller", "-c", "controller_manager"],
+    )
+
+    epick_controller_spawner = launch_ros.actions.Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace="robotiq_epick_gripper",
+        arguments=["epick_controller", "-c", "controller_manager"],
+    )
+
+    nodes = [
+        control_node,
+        epick_controller_spawner,
+        epick_status_controller_spawner,
+        # epick_activation_controller_spawner
+    ]
+
+    return launch.LaunchDescription(args + nodes)

--- a/rox_bringup/configs/ur/controllers.yaml
+++ b/rox_bringup/configs/ur/controllers.yaml
@@ -27,6 +27,11 @@ controller_manager:
     forward_position_controller:
       type: position_controllers/JointGroupPositionController
 
+    robotiq_2f_140_gripper_controller:
+      type: position_controllers/GripperActionController
+
+    robotiq_2f_85_gripper_controller:
+      type: position_controllers/GripperActionController
 
 speed_scaling_state_broadcaster:
   ros__parameters:
@@ -49,7 +54,6 @@ force_torque_sensor_broadcaster:
       - torque.z
     frame_id: $(var arm_type)tool0
     topic_name: ft_data
-
 
 joint_trajectory_controller:
   ros__parameters:
@@ -77,7 +81,6 @@ joint_trajectory_controller:
       $(var arm_type)wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
       $(var arm_type)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       $(var arm_type)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
-
 
 scaled_joint_trajectory_controller:
   ros__parameters:
@@ -127,3 +130,18 @@ forward_position_controller:
       - $(var arm_type)wrist_1_joint
       - $(var arm_type)wrist_2_joint
       - $(var arm_type)wrist_3_joint
+
+# Robotiq gripper controller
+robotiq_2f_140_gripper_controller:
+  ros__parameters:
+    default: true
+    joint: finger_joint # for 2f_140 gripper
+    use_effort_interface: true
+    use_speed_interface: true
+
+robotiq_2f_85_gripper_controller:
+  ros__parameters:
+    default: true
+    joint: robotiq_85_left_knuckle_joint
+    use_effort_interface: true
+    use_speed_interface: true

--- a/rox_bringup/configs/ur/initial_joint_positions.yaml
+++ b/rox_bringup/configs/ur/initial_joint_positions.yaml
@@ -1,6 +1,6 @@
 shoulder_pan_joint: 1.5
 shoulder_lift_joint: -2.5
-elbow_joint: 2.0
-wrist_1_joint: 0.0
+elbow_joint: 1.75
+wrist_1_joint: -0.75
 wrist_2_joint: -1.5
 wrist_3_joint: 0.0

--- a/rox_bringup/launch/bringup_launch.py
+++ b/rox_bringup/launch/bringup_launch.py
@@ -23,32 +23,55 @@ def execution_stage(context: LaunchContext,
                     arm_type,
                     scanner_type,
                     use_imu,
+                    d435_enable,
                     ur_dc,
-                    mock_arm):
-
-    launch_actions = []
+                    mock_arm,
+                    robot_ip,
+                    controllers_yaml,
+                    gripper_type):
 
     rox = get_package_share_directory('rox_bringup')
-
-    arm_typ = str(arm_type.perform(context))
+    
     rox_typ = str(rox_type.perform(context))
     scanner_typ = str(scanner_type.perform(context))
     imu_enable = str(use_imu.perform(context))
+    d435_enabl = str(d435_enable.perform(context))
+
+    # Manipulator launch arguments
+    arm_typ = str(arm_type.perform(context))
     use_ur_dc = str(ur_dc.perform(context))
     use_mock = str(mock_arm.perform(context))
+    gripper_typ = str(gripper_type.perform(context))
+
+    launch_actions = []
 
     joint_type = "revolute"
-
-    if use_mock:
+    if use_mock.lower() == "true":
         joint_type = "fixed"
-
-    launches = []
 
     rp_ns = ""
     if (robot_namespace.perform(context) != "/"):
         rp_ns = robot_namespace.perform(context) + "/"
 
-    urdf = os.path.join(get_package_share_directory('rox_description'), 'urdf', 'rox.urdf.xacro')
+    urdf = os.path.join(get_package_share_directory('rox_description'), 
+                        'urdf', 
+                        'rox.urdf.xacro')
+
+    xacro_args = [
+        "xacro", " ", urdf,
+        " ", 'rox_type:=', rox_typ,
+        " ", 'arm_type:=', arm_typ,
+        " ", 'robot_ip:=', "yyy.yyy.yyy.yyy",
+        " ", 'gripper_type:=', gripper_typ,
+        " ", 'use_mock_hardware:=', use_mock,
+        " ", 'use_mock_sensor_commands:=', use_mock,
+        " ", 'scanner_type:=', scanner_typ,
+        " ", 'use_imu:=', imu_enable,
+        " ", 'use_ur_dc:=', use_ur_dc,
+        " ", 'joint_type:=', joint_type
+    ]
+    if arm_typ != "":
+        xacro_args.extend([" include_arm_ros2_control:=", "true"]) # Include only the arm ros2_control tags
 
     start_robot_state_publisher_cmd = Node(
         package='robot_state_publisher',
@@ -56,26 +79,18 @@ def execution_stage(context: LaunchContext,
         name='robot_state_publisher',
         output='screen',
         parameters=[{
-            'robot_description': ParameterValue(
-                Command([
-                    "xacro", " ", urdf,
-                    " ", 'arm_type:=', arm_typ,
-                    " ", 'rox_type:=', rox_typ,
-                    " ", 'robot_ip:=', "yyy.yyy.yyy.yyy",
-                    " ", 'use_mock_hardware:=', use_mock,
-                    " ", 'scanner:=', scanner_typ,
-                    " ", 'use_imu:=', imu_enable,
-                    " ", 'use_ur_dc:=', use_ur_dc,
-                    " ", 'joint_type:=', joint_type
-                ]),
-                value_type=str
-            ),
-            'frame_prefix': rp_ns # Not yet supported
-        }]
+            'robot_description': ParameterValue(Command(xacro_args), value_type=str),
+            'frame_prefix': rp_ns
+        }],
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static'),
+            ],
     )
 
     launch_actions.append(start_robot_state_publisher_cmd)
 
+    #  Launch hardware nodes
     # 1. Relayboard
     relayboard = Node(
         package='neo_relayboard_v3', 
@@ -147,13 +162,15 @@ def execution_stage(context: LaunchContext,
                 name="lidar_1_node",
                 output="screen",
                 emulate_tty=True,
-                parameters=[os.path.join(rox, 'configs/sick_lidar', 'nanoscan_1.yaml')],
+                parameters=[os.path.join(rox, 
+                                'configs/sick_lidar', 
+                                'nanoscan_1.yaml')],
                 condition=UnlessCondition(mock_arm),
                 remappings=[
                     ('/scan', '/lidar_1/scan_filtered')
                 ]
             )
-        
+
         launch_actions.append(scan1)
 
         scan2 = Node(
@@ -162,7 +179,9 @@ def execution_stage(context: LaunchContext,
                 name="lidar_2_node",
                 output="screen",
                 emulate_tty=True,
-                parameters=[os.path.join(rox, 'configs/sick_lidar', 'nanoscan_2.yaml')],
+                parameters=[os.path.join(rox, 
+                                'configs/sick_lidar', 
+                                'nanoscan_2.yaml')],
                 condition=UnlessCondition(mock_arm),
                 remappings=[
                     ('/scan', '/lidar_2/scan_filtered'),
@@ -189,10 +208,12 @@ def execution_stage(context: LaunchContext,
         launch_actions.append(scan)
 
     # 5. IMU
-    if imu_enable == 'True':
+    if imu_enable.lower == 'true':
         imu = IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(rox, 'configs/phidget_imu', 'imu_launch.py')
+                os.path.join(rox, 
+                    'configs/phidget_imu', 
+                    'imu_launch.py')
             ),
             launch_arguments={
                 'namespace': robot_namespace
@@ -202,7 +223,21 @@ def execution_stage(context: LaunchContext,
 
         launch_actions.append(imu)
 
-    # 6. Arm - Bringing up drivers for Universal Arm
+    # 6. D435
+    # TODO: Add support for namespacing
+    if d435_enabl.lower == 'true':
+        d435 = IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(rox,
+                        'configs/realsense',
+                        'rs_launch.py')
+                ),
+                condition=UnlessCondition(mock_arm)
+            )
+
+        launch_actions.append(d435)
+
+    # 7. Arm - Bringing up drivers for Universal Arm
     # TODO: Add support for Elite Robots
     # TODO: Add support for namespacing
     if (arm_typ == "ur5" or
@@ -221,15 +256,56 @@ def execution_stage(context: LaunchContext,
                 ),
                 launch_arguments={
                     'ur_type': arm_typ,
-                    'robot_ip': "192.168.1.102",
+                    'robot_ip': robot_ip,
                     'tf_prefix': arm_typ,
                     'use_mock_hardware': use_mock,
                     'mock_sensor_commands': use_mock,
-                    'initial_joint_controller': initial_joint_controller
+                    'initial_joint_controller': initial_joint_controller,
+                    'controllers_file': controllers_yaml,
                 }.items()
             )
 
         launch_actions.append(ur_arm)
+
+        # Conditionally add grippers
+        if gripper_typ != "":
+            gripper_xacro_args = xacro_args.copy()
+            gripper_xacro_args.extend([
+                " include_gripper_ros2_control:=", "true",# Include only the gripper ros2_control tags
+                " include_arm_ros2_control:=", "false"])
+
+            # For 2f_140
+            if (gripper_typ == "2f_140" or gripper_typ == "2f_85"):
+                robotiq_2f_gripper = IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        os.path.join(rox,
+                                'configs/robotiq',
+                                'robotiq_control.launch.py')
+                        ),
+                        launch_arguments={
+                            'robot_description_content': Command(gripper_xacro_args),
+                            'use_mock_hardware': use_mock,
+                            'model': os.path.join(get_package_share_directory('robotiq_description'),
+                                            "urdf", 
+                                            f"robotiq_{gripper_typ}_gripper.urdf.xacro"
+                                            ),
+                            'controllers_file': f"robotiq_{gripper_typ}_controllers.yaml"
+                        }.items()
+                    )
+
+                launch_actions.append(robotiq_2f_gripper)
+
+            # For Epick
+            elif (gripper_typ == "epick"):
+                gripper_epick = IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        os.path.join(rox,
+                                'configs/robotiq',
+                                'robotiq_epick_control.launch.py')
+                        )
+                    )
+
+                launch_actions.append(gripper_epick)
 
     # Relaying lidar data to /scan topic
     relay_topic_lidar1 = Node(
@@ -270,19 +346,6 @@ def execution_stage(context: LaunchContext,
 
 def generate_launch_description():
 
-    # Launch configuration
-    robot_namespace = LaunchConfiguration('robot_namespace')
-    rox_type = LaunchConfiguration('rox_type')
-    arm_type = LaunchConfiguration('arm_type')
-    scanner_type = LaunchConfiguration('scanner_type')
-    imu_enable = LaunchConfiguration('imu_enable')
-    ur_dc = LaunchConfiguration('use_ur_dc')
-    mock_arm = LaunchConfiguration('use_mock_arm')
-
-    context_arguments = [robot_namespace, rox_type, arm_type, scanner_type, imu_enable, ur_dc, mock_arm]
-
-    opq_function = OpaqueFunction(function=execution_stage, args=context_arguments)
-
     declare_namespace_cmd = DeclareLaunchArgument(
             'robot_namespace', default_value='', description='Top-level namespace'
         )
@@ -298,15 +361,20 @@ def generate_launch_description():
             description='Enable IMU - Options: True/False'
         )
 
-    declare_arm_cmd = DeclareLaunchArgument(
-            'arm_type', default_value='',
-            choices=['', 'ur5', 'ur10', 'ur5e', 'ur10e'],
-            description='Arm used in the robot - currently only Universal Robotics arms are supported\n\t'
+    declare_realsense_cmd = DeclareLaunchArgument(
+            'd435_enable', default_value='False',
+            description='Enable Realsense - Options: True/False'
         )
 
     declare_scanner_cmd = DeclareLaunchArgument(
             'scanner_type', default_value='nanoscan',
             description='Scanner options available: nanoscan/psenscan'
+        )
+
+    declare_arm_cmd = DeclareLaunchArgument(
+            'arm_type', default_value='',
+            choices=['', 'ur5', 'ur10', 'ur5e', 'ur10e'],
+            description='Arm used in the robot - currently only Universal Robotics arms are supported\n\t'
         )
 
     declare_ur_pwr_variant_cmd = DeclareLaunchArgument(
@@ -319,17 +387,41 @@ def generate_launch_description():
             description="Mock arm and gripper (if available)"
         )
 
+    declare_robot_ip_cmd = DeclareLaunchArgument(
+            'robot_ip', default_value='192.168.1.102',
+            description='IP address of the robot arm.'
+        )
+
+    declare_controllers_file_cmd = DeclareLaunchArgument(
+            'controllers_file',
+            default_value=os.path.join(
+                get_package_share_directory('neo_mpo_700-2'),
+                'configs/ur/ur_controllers.yaml'
+            ),
+            description='YAML file with the arm controllers configuration.',
+        )
+
+    declare_robotiq_cmd = DeclareLaunchArgument(
+            'gripper_type', default_value='',
+            choices=['', '2f_140', '2f_85', 'epick'],
+            description="Enables gripper and it's controllers"
+        )
+
     opq_function = OpaqueFunction(
-    function=execution_stage,
-    args=[
-        LaunchConfiguration('robot_namespace'),
-        LaunchConfiguration('rox_type'),
-        LaunchConfiguration('arm_type'),
-        LaunchConfiguration('scanner_type'),
-        LaunchConfiguration('imu_enable'),
-        LaunchConfiguration('use_ur_dc'),
-        LaunchConfiguration('use_mock_arm'),
-        ])  
+        function=execution_stage,
+        args=[
+            LaunchConfiguration('robot_namespace'),
+            LaunchConfiguration('rox_type'),
+            LaunchConfiguration('arm_type'),
+            LaunchConfiguration('scanner_type'),
+            LaunchConfiguration('imu_enable'),
+            LaunchConfiguration('d435_enable'),
+            LaunchConfiguration('use_ur_dc'),
+            LaunchConfiguration('use_mock_arm'),
+            LaunchConfiguration('robot_ip'),
+            LaunchConfiguration('controllers_file'),
+            LaunchConfiguration('gripper_type'),
+            ])  
 
     ld = LaunchDescription([
         declare_namespace_cmd,
@@ -337,8 +429,12 @@ def generate_launch_description():
         declare_arm_cmd,
         declare_scanner_cmd,
         declare_imu_cmd,
+        declare_realsense_cmd,
         declare_ur_pwr_variant_cmd,
         declare_mock_arm_cmd,
+        declare_robot_ip_cmd,
+        declare_controllers_file_cmd,
+        declare_robotiq_cmd,
         opq_function
     ])
     return ld

--- a/rox_bringup/launch/bringup_launch.py
+++ b/rox_bringup/launch/bringup_launch.py
@@ -23,7 +23,6 @@ def execution_stage(context: LaunchContext,
                     arm_type,
                     scanner_type,
                     use_imu,
-                    d435_enable,
                     ur_dc,
                     mock_arm,
                     robot_ip,
@@ -35,7 +34,6 @@ def execution_stage(context: LaunchContext,
     rox_typ = str(rox_type.perform(context))
     scanner_typ = str(scanner_type.perform(context))
     imu_enable = str(use_imu.perform(context))
-    d435_enabl = str(d435_enable.perform(context))
 
     # Manipulator launch arguments
     arm_typ = str(arm_type.perform(context))
@@ -223,20 +221,6 @@ def execution_stage(context: LaunchContext,
 
         launch_actions.append(imu)
 
-    # 6. D435
-    # TODO: Add support for namespacing
-    if d435_enabl.lower == 'true':
-        d435 = IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(rox,
-                        'configs/realsense',
-                        'rs_launch.py')
-                ),
-                condition=UnlessCondition(mock_arm)
-            )
-
-        launch_actions.append(d435)
-
     # 7. Arm - Bringing up drivers for Universal Arm
     # TODO: Add support for Elite Robots
     # TODO: Add support for namespacing
@@ -361,11 +345,6 @@ def generate_launch_description():
             description='Enable IMU - Options: True/False'
         )
 
-    declare_realsense_cmd = DeclareLaunchArgument(
-            'd435_enable', default_value='False',
-            description='Enable Realsense - Options: True/False'
-        )
-
     declare_scanner_cmd = DeclareLaunchArgument(
             'scanner_type', default_value='nanoscan',
             description='Scanner options available: nanoscan/psenscan'
@@ -415,7 +394,6 @@ def generate_launch_description():
             LaunchConfiguration('arm_type'),
             LaunchConfiguration('scanner_type'),
             LaunchConfiguration('imu_enable'),
-            LaunchConfiguration('d435_enable'),
             LaunchConfiguration('use_ur_dc'),
             LaunchConfiguration('use_mock_arm'),
             LaunchConfiguration('robot_ip'),
@@ -429,7 +407,6 @@ def generate_launch_description():
         declare_arm_cmd,
         declare_scanner_cmd,
         declare_imu_cmd,
-        declare_realsense_cmd,
         declare_ur_pwr_variant_cmd,
         declare_mock_arm_cmd,
         declare_robot_ip_cmd,

--- a/rox_bringup/launch/bringup_sim_launch.py
+++ b/rox_bringup/launch/bringup_sim_launch.py
@@ -19,26 +19,35 @@ import xacro
 def execution_stage(context: LaunchContext, 
                     rox_type,
                     arm_type,
-                    d435_enable,
                     imu_enable,
+                    d435_enable,
+                    scanner_type,
                     ur_dc,
+                    gripper_type,
                     headless_sim):
 
     launch_actions = []
 
-    default_world_path = os.path.join(get_package_share_directory('neo_gz_worlds'), 'worlds', 'neo_workshop.sdf')
-    bridge_config_file = os.path.join(get_package_share_directory('rox_bringup'), 'configs/gz_bridge', 'gz_bridge_config.yaml')
-    arm_typ = str(arm_type.perform(context))
     rox_typ = str(rox_type.perform(context))
+    arm_typ = str(arm_type.perform(context))
+    gripper_typ = str(gripper_type.perform(context))
+    scanner_typ = str(scanner_type.perform(context))
     d435 = str(d435_enable.perform(context))
     imu = str(imu_enable.perform(context))
     use_ur_dc = str(ur_dc.perform(context))
     headless_sim = str(headless_sim.perform(context)).lower()
     joint_type = "fixed"
 
+    default_world_path = os.path.join(get_package_share_directory('neo_gz_worlds'), 'worlds', 'neo_workshop.sdf')
+    bridge_config_file = os.path.join(get_package_share_directory('rox_bringup'), 'configs/gz_bridge', 'gz_bridge_config.yaml')
+
+    include_gripper_ros2_control = "false"
+    include_arm_ros2_control = "false"
+
     if (rox_typ == "diff" or rox_typ == "trike"):
         joint_type = "revolute"
 
+    # Getting the robot description xacro
     urdf = os.path.join(get_package_share_directory('rox_description'), 'urdf', 'rox.urdf.xacro')
 
     spawn_robot = Node(
@@ -62,16 +71,18 @@ def execution_stage(context: LaunchContext,
         launch_arguments={'gz_args': gz_args}.items()
       )
 
+    # Simulation Controllers for the arm
     arm_manufacturer = None
     initial_joint_controller_name = "joint_trajectory_controller"
+    initial_gripper_controller_name = ""
     if arm_typ:
+        include_arm_ros2_control = "true"
         if arm_typ in ['ec66', 'cs66']:
             arm_manufacturer = 'elite'
             initial_joint_controller_name = 'arm_controller'
         elif arm_typ in ['ur5', 'ur10', 'ur5e', 'ur10e']:
             arm_manufacturer = 'ur'
 
-    if arm_manufacturer is not None:
         controllers_yaml = os.path.join(
             get_package_share_directory('rox_bringup'),
             'configs', 
@@ -89,8 +100,36 @@ def execution_stage(context: LaunchContext,
         )
         launch_actions.extend(shutdown_handler)
 
+        if gripper_typ:
+            include_gripper_ros2_control = "true"
+            gripper_category = None
+            if gripper_typ == 'epick':
+                gripper_category = 'epick'
+                initial_gripper_controller_name = 'epick_controller'
+            elif gripper_typ in ['2f_140', '2f_85']:
+                gripper_category = 'robotiq'
+                initial_gripper_controller_name = f'robotiq_{gripper_typ}_gripper_controller'
+            include_gripper_ros2_control = "true"
+
     else:
         simulation_controllers = ""
+
+    xacro_args = [
+        "xacro", " ", urdf,
+        " ", 'use_gz:=', "true",
+        " ", 'rox_type:=', rox_typ,
+        " ", 'joint_type:=', joint_type,
+        " ", 'use_imu:=', imu,
+        " ", 'd435_enable:=', d435,
+        " ", 'scanner_type:=', scanner_typ,
+        " ", 'arm_type:=', arm_typ,
+        " ", 'gripper_type:=', gripper_typ,
+        " ", 'use_ur_dc:=', use_ur_dc,
+        " ", 'force_abs_paths:=', "true",
+        " ", 'simulation_controllers:=', simulation_controllers,
+        " ", 'include_arm_ros2_control:=', include_arm_ros2_control,
+        " ", 'include_gripper_ros2_control:=', include_gripper_ros2_control
+    ]
 
     start_robot_state_publisher_cmd = Node(
         package='robot_state_publisher',
@@ -99,22 +138,8 @@ def execution_stage(context: LaunchContext,
         output='screen',
         parameters=[{
             'use_sim_time': True,  # Set use_sim_time as True for simulation
-            'robot_description': ParameterValue(
-                Command([
-                    "xacro", " ", urdf,
-                    " ", 'arm_type:=', arm_typ,
-                    " ", 'rox_type:=', rox_typ,
-                    " ", 'joint_type:=', joint_type,
-                    " ", 'use_imu:=', imu,
-                    " ", 'd435_enable:=', d435,
-                    " ", 'use_gz:=', "true",
-                    " ", 'use_ur_dc:=', use_ur_dc,
-                    " ", 'force_abs_paths:=', "true",
-                    " ", 'simulation_controllers:=', simulation_controllers
-                ]), 
-                value_type=str
-            )
-        }]
+            'robot_description': ParameterValue(Command(xacro_args), value_type=str),
+        }],
     )
 
     teleop =  Node(
@@ -146,16 +171,30 @@ def execution_stage(context: LaunchContext,
         arguments=[initial_joint_controller_name, "-c", "/controller_manager"],
     )
 
+    robotiq_gripper_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[initial_gripper_controller_name, "-c", "/controller_manager"]
+    )
+
     env_var_value = (
         os.path.join(get_package_share_directory('neo_gz_worlds'), 'models') +
         ':' +
         os.path.dirname(get_package_share_directory('rox_description'))
     )
 
-    if arm_typ == 'ec66' or arm_typ == 'cs66':
-        env_var_value += ':' + os.path.dirname(get_package_share_directory('elite_description'))
-
-    # Set environment variable
+    if arm_typ:
+        # Set environment variable for arm description packages
+        if arm_typ == 'ec66' or arm_typ == 'cs66':
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('elite_description'))
+        elif arm_typ == 'ur5' or arm_typ == 'ur10' or arm_typ == 'ur5e' or arm_typ == 'ur10e':
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('ur_description'))
+        # Set environment variable for gripper description packages
+        if gripper_typ == 'epick':
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('epick_description'))
+        else:
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('robotiq_description'))
+            
     set_env_vars_resources = AppendEnvironmentVariable('GZ_SIM_RESOURCE_PATH', env_var_value)
 
     launch_actions.append(set_env_vars_resources)
@@ -168,13 +207,15 @@ def execution_stage(context: LaunchContext,
     if arm_typ != '':
         launch_actions.append(joint_state_broadcaster_spawner)
         launch_actions.append(initial_joint_controller_spawner_started)
+        if gripper_typ == '2f_140' or gripper_typ == '2f_85':
+            launch_actions.append(robotiq_gripper_controller_spawner)
 
     return launch_actions
 
 def generate_launch_description():
 
     declare_rox_type_cmd = DeclareLaunchArgument(
-            'rox_type', default_value='argo',
+            'rox_type',default_value='argo',
             choices = ['', 'argo', 'argo-trio', 'diff', 'trike'],
             description='ROX Drive Type\n\t'
         )
@@ -189,15 +230,27 @@ def generate_launch_description():
             description='Enable Realsense - Options: True/False'
         )
 
+    declare_scanner_cmd = DeclareLaunchArgument(
+            'scanner_type', default_value='nanoscan',
+            choices = ['', 'nanoscan', 'psenscan'],
+            description='Scanner Type'
+        )
+
     declare_arm_type_cmd = DeclareLaunchArgument(
             'arm_type', default_value='',
             choices=['', 'ur5', 'ur10', 'ur5e', 'ur10e', 'ec66', 'cs66'],
-            description='Arm Types\n\t'        
+            description='Arm Types\n\t'
         )
 
     declare_ur_pwr_variant_cmd = DeclareLaunchArgument(
             'use_ur_dc', default_value='False',
             description='Set this argument to True if you have an UR arm with DC variant'
+        )
+
+    declare_gripper_type_cmd = DeclareLaunchArgument(
+            'gripper_type', default_value='',
+            choices=['', '2f_140', '2f_85'],
+            description='Gripper Types - Supported Robots [mpo-700, mpo-500]\n\t'
         )
 
     declare_headless_sim_cmd = DeclareLaunchArgument(
@@ -212,16 +265,20 @@ def generate_launch_description():
             LaunchConfiguration('arm_type'),
             LaunchConfiguration('d435_enable'),
             LaunchConfiguration('imu_enable'),
+            LaunchConfiguration('scanner_type'),
             LaunchConfiguration('use_ur_dc'),
+            LaunchConfiguration('gripper_type'),
             LaunchConfiguration('headless_simulation')
             ])
 
     ld = LaunchDescription([
         declare_imu_cmd,
         declare_realsense_cmd,
+        declare_scanner_cmd,
         declare_arm_type_cmd,
         declare_rox_type_cmd,
         declare_ur_pwr_variant_cmd,
+        declare_gripper_type_cmd,
         declare_headless_sim_cmd,
         opq_function
     ])

--- a/rox_description/urdf/rox.urdf.xacro
+++ b/rox_description/urdf/rox.urdf.xacro
@@ -7,28 +7,37 @@ Contributor: Adarsh Karan K P
 <!-- This is the main URDF file for rox robot -->
 
   <!-- Xacro Arguments-->
-  <xacro:arg name="rox_type" default="argo"/>
-  <xacro:arg name="joint_type" default="fixed"/>
-  <xacro:arg name="scanner" default="nanoscan"/>
-  <xacro:arg name="arm_type" default=""/>
   <xacro:arg name="use_gz" default="false"/>
   <xacro:arg name="use_imu" default="false"/>
   <xacro:arg name="use_d435" default="false"/>
-  <xacro:arg name="use_ur_dc" default="false"/>
+  <xacro:arg name="scanner_type" default="nanoscan"/>
+  <xacro:arg name="rox_type" default="argo"/>
+  <xacro:arg name="joint_type" default="fixed"/>
+
+  <!-- Manipulator Arguments-->
+  <xacro:arg name="arm_type" default=""/>
   <xacro:arg name="arm_parent" default="cabinet_link"/>
+  <xacro:arg name="gripper_type" default=""/>
+  <xacro:arg name="use_ur_dc" default="false"/>
   <xacro:arg name="force_abs_paths" default="false"/>
   <xacro:arg name="simulation_controllers" default=""/>
   <xacro:arg name="use_mock_hardware" default="false" />
   <xacro:arg name="mock_sensor_commands" default="false" />
+
+  <xacro:arg name="include_arm_ros2_control" default="false"/>
+  <xacro:arg name="include_gripper_ros2_control" default="false"/>
+
   <!-- Xacro Properties -->
-  <xacro:property name="rox_typ" default="$(arg rox_type)"/>
-  <xacro:property name="joint_typ" value="$(arg joint_type)"/>
-  <xacro:property name="scanner_typ" value="$(arg scanner)"/>
-  <xacro:property name="arm" value="$(arg arm_type)"/>
   <xacro:property name="gz" value="$(arg use_gz)"/>
   <xacro:property name="imu" value="$(arg use_imu)"/>
   <xacro:property name="d435" value="$(arg use_d435)"/>
+  <xacro:property name="scanner" value="$(arg scanner_type)"/>
+  <xacro:property name="rox_typ" value="$(arg rox_type)"/>
+  <xacro:property name="joint_typ" value="$(arg joint_type)"/>
+  <xacro:property name="arm" value="$(arg arm_type)"/>
   <xacro:property name="ur_dc" value="$(arg use_ur_dc)"/>
+  <xacro:property name="gripper" value="$(arg gripper_type)"/>
+  <xacro:property name="use_mock" value="$(arg use_mock_hardware)"/>
 
   <!-- Include xacro files -->
   <xacro:include filename="$(find rox_description)/urdf/xacros/frame.xacro" />
@@ -77,7 +86,7 @@ Contributor: Adarsh Karan K P
   <!-- Laser scanners -->
 
   <!-- Nanoscans -->
-  <xacro:if value="${scanner_typ == 'nanoscan'}">
+  <xacro:if value="${scanner == 'nanoscan'}">
     <xacro:sick_nanoscan name="lidar_1" parent="base_link">
       <origin rpy="${pi} 0 ${pi/4}" xyz="${0.2995} 0.269 0.189"/>
     </xacro:sick_nanoscan>
@@ -88,7 +97,7 @@ Contributor: Adarsh Karan K P
   </xacro:if>
   
   <!-- Pilz -->
-  <xacro:if value="${scanner_typ == 'psenscan'}">
+  <xacro:if value="${scanner == 'psenscan'}">
     <xacro:pilz_psenscan name="lidar_1" parent="base_link">
       <origin rpy="0 0 ${pi/4}" xyz="${0.3016} 0.2719 0.191"/>
     </xacro:pilz_psenscan>
@@ -160,6 +169,44 @@ Contributor: Adarsh Karan K P
       <xacro:property name="arm_height" value="0.376" />
       <xacro:include filename="$(find rox_description)/urdf/xacros/elite_arm.urdf.xacro"/>
     </xacro:if>
+
+    <!-- add gripper-->
+    <xacro:unless value="${gripper == ''}">
+
+      <!-- ur_adapter for gripper-->
+      <xacro:if value="${gripper == '2f_140' or gripper == '2f_85'}">
+        <xacro:include filename="$(find robotiq_description)/urdf/ur_to_robotiq_adapter.urdf.xacro"/>
+        <xacro:ur_to_robotiq 
+          prefix="" 
+          parent="$(arg tf_prefix)tool0"
+          child="neo_gripper_mount_link"
+          rotation="${pi/2}"
+          />
+
+        <xacro:include filename="$(find robotiq_description)/urdf/robotiq_${gripper}_macro.urdf.xacro"/>
+        <xacro:robotiq_gripper name="robotiq_gripper"
+          prefix=""
+          parent="neo_gripper_mount_link"
+          use_mock_hardware="${use_mock}"
+          mock_sensor_commands="${use_mock}"
+          sim_gazebo="${gz}"
+          include_ros2_control="$(arg include_gripper_ros2_control)"
+          >
+          <origin xyz="0 0 0" rpy="0 0 -${pi / 2}"/>
+        </xacro:robotiq_gripper>
+
+      </xacro:if>
+
+      <xacro:if value="${gripper == 'epick'}">
+        <xacro:include filename="$(find epick_description)/urdf/epick_single_suction_cup.xacro"/>
+        <xacro:epick_single_suction_cup parent="$(arg tf_prefix)tool0"
+          use_fake_hardware="${use_mock}"
+          origin_xyz="0 0 0"
+          origin_rpy="0 0 -${pi / 2}"
+          />
+      </xacro:if>
+
+    </xacro:unless>
 
   </xacro:unless>
 

--- a/rox_description/urdf/xacros/elite_arm.urdf.xacro
+++ b/rox_description/urdf/xacros/elite_arm.urdf.xacro
@@ -66,7 +66,5 @@ Contributor: Adarsh Karan K P
       initial_positions="${elite_initial_positions}"
       />
   </xacro:if>
-  <!-- include robotiq gripper-->
-  <!-- <xacro:include filename="$(find neo_simulation2)/components/arm/robotiq_gripper.urdf.xacro"/> -->
 
 </robot>

--- a/rox_description/urdf/xacros/trike_drive.xacro
+++ b/rox_description/urdf/xacros/trike_drive.xacro
@@ -25,5 +25,5 @@
     </xacro:diff_wheel>
 
   </xacro:macro>
-  
+
 </robot>

--- a/rox_description/urdf/xacros/ur_arm.urdf.xacro
+++ b/rox_description/urdf/xacros/ur_arm.urdf.xacro
@@ -12,6 +12,7 @@ Contributor: Adarsh Karan K P
 
   <!-- Set use_gz = true for simulation -->
   <xacro:arg name="use_gz" default="false"/>
+  <xacro:arg name="include_arm_ros2_control" default="false"/>
 
   <!-- arm parameters -->
   <xacro:arg name="arm_type" default="ur10"/>
@@ -61,60 +62,61 @@ Contributor: Adarsh Karan K P
 
   <!-- this condition is to ensure that ros2_control doesn't interfere with gz_ros2_control during simulation  -->
   <xacro:unless value="$(arg use_gz)">
+    <xacro:if value="$(arg include_arm_ros2_control)">
+      <!-- ros2_control related parameters -->
+      <xacro:arg name="headless_mode" default="false" />
+      <xacro:arg name="robot_ip" default="192.168.1.102" />
+      <xacro:arg name="script_filename" default="$(find ur_client_library)/resources/external_control.urscript"/>
+      <xacro:arg name="output_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"/>
+      <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
+      <xacro:arg name="reverse_ip" default="0.0.0.0"/>
+      <xacro:arg name="script_command_port" default="50004"/>
+      <xacro:arg name="reverse_port" default="50001"/>
+      <xacro:arg name="script_sender_port" default="50002"/>
+      <xacro:arg name="trajectory_port" default="50003"/>
+      <!-- tool communication related parameters-->
+      <xacro:arg name="use_tool_communication" default="false" />
+      <xacro:arg name="tool_voltage" default="0" />
+      <xacro:arg name="tool_parity" default="0" />
+      <xacro:arg name="tool_baud_rate" default="115200" />
+      <xacro:arg name="tool_stop_bits" default="1" />
+      <xacro:arg name="tool_rx_idle_chars" default="1.5" />
+      <xacro:arg name="tool_tx_idle_chars" default="3.5" />
+      <xacro:arg name="tool_device_name" default="/tmp/ttyUR" />
+      <xacro:arg name="tool_tcp_port" default="54321" />
+      
+      <xacro:arg name="use_mock_hardware" default="false" />
+      <xacro:arg name="mock_sensor_commands" default="false" />
 
-    <!-- ros2_control related parameters -->
-    <xacro:arg name="headless_mode" default="false" />
-    <xacro:arg name="robot_ip" default="192.168.1.102" />
-    <xacro:arg name="script_filename" default="$(find ur_client_library)/resources/external_control.urscript"/>
-    <xacro:arg name="output_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"/>
-    <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
-    <xacro:arg name="reverse_ip" default="0.0.0.0"/>
-    <xacro:arg name="script_command_port" default="50004"/>
-    <xacro:arg name="reverse_port" default="50001"/>
-    <xacro:arg name="script_sender_port" default="50002"/>
-    <xacro:arg name="trajectory_port" default="50003"/>
-    <!-- tool communication related parameters-->
-    <xacro:arg name="use_tool_communication" default="false" />
-    <xacro:arg name="tool_voltage" default="0" />
-    <xacro:arg name="tool_parity" default="0" />
-    <xacro:arg name="tool_baud_rate" default="115200" />
-    <xacro:arg name="tool_stop_bits" default="1" />
-    <xacro:arg name="tool_rx_idle_chars" default="1.5" />
-    <xacro:arg name="tool_tx_idle_chars" default="3.5" />
-    <xacro:arg name="tool_device_name" default="/tmp/ttyUR" />
-    <xacro:arg name="tool_tcp_port" default="54321" />
-    
-    <xacro:arg name="use_mock_hardware" default="false" />
-    <xacro:arg name="mock_sensor_commands" default="false" />
-
-    <xacro:ur_ros2_control
-      name="$(arg arm_type)"
-      tf_prefix="$(arg tf_prefix)"
-      kinematics_parameters_file="$(arg kinematics_params)"
-      transmission_hw_interface="$(arg transmission_hw_interface)"
-      headless_mode="$(arg headless_mode)"
-      initial_positions="${ur_initial_positions}"
-      use_tool_communication="$(arg use_tool_communication)"
-      tool_voltage="$(arg tool_voltage)"
-      tool_parity="$(arg tool_parity)"
-      tool_baud_rate="$(arg tool_baud_rate)"
-      tool_stop_bits="$(arg tool_stop_bits)"
-      tool_rx_idle_chars="$(arg tool_rx_idle_chars)"
-      tool_tx_idle_chars="$(arg tool_tx_idle_chars)"
-      tool_device_name="$(arg tool_device_name)"
-      tool_tcp_port="$(arg tool_tcp_port)"
-      robot_ip="$(arg robot_ip)"
-      script_filename="$(arg script_filename)"
-      output_recipe_filename="$(arg output_recipe_filename)"
-      input_recipe_filename="$(arg input_recipe_filename)"
-      reverse_ip="$(arg reverse_ip)"
-      script_command_port="$(arg script_command_port)"
-      reverse_port="$(arg reverse_port)"
-      script_sender_port="$(arg script_sender_port)"
-      trajectory_port="$(arg trajectory_port)"
-      use_mock_hardware="$(arg use_mock_hardware)"
-      mock_sensor_commands="$(arg mock_sensor_commands)"
-      />
+      <xacro:ur_ros2_control
+        name="$(arg arm_type)"
+        tf_prefix="$(arg tf_prefix)"
+        kinematics_parameters_file="$(arg kinematics_params)"
+        transmission_hw_interface="$(arg transmission_hw_interface)"
+        headless_mode="$(arg headless_mode)"
+        initial_positions="${ur_initial_positions}"
+        use_tool_communication="$(arg use_tool_communication)"
+        tool_voltage="$(arg tool_voltage)"
+        tool_parity="$(arg tool_parity)"
+        tool_baud_rate="$(arg tool_baud_rate)"
+        tool_stop_bits="$(arg tool_stop_bits)"
+        tool_rx_idle_chars="$(arg tool_rx_idle_chars)"
+        tool_tx_idle_chars="$(arg tool_tx_idle_chars)"
+        tool_device_name="$(arg tool_device_name)"
+        tool_tcp_port="$(arg tool_tcp_port)"
+        robot_ip="$(arg robot_ip)"
+        script_filename="$(arg script_filename)"
+        output_recipe_filename="$(arg output_recipe_filename)"
+        input_recipe_filename="$(arg input_recipe_filename)"
+        reverse_ip="$(arg reverse_ip)"
+        script_command_port="$(arg script_command_port)"
+        reverse_port="$(arg reverse_port)"
+        script_sender_port="$(arg script_sender_port)"
+        trajectory_port="$(arg trajectory_port)"
+        use_mock_hardware="$(arg use_mock_hardware)"
+        mock_sensor_commands="$(arg mock_sensor_commands)"
+        />
+    </xacro:if>
   </xacro:unless>
 
   <!-- If gz simulation is used -->
@@ -140,9 +142,7 @@ Contributor: Adarsh Karan K P
       transmission_hw_interface="$(arg transmission_hw_interface)"
       initial_positions="${ur_initial_positions}"
       />
-  </xacro:if>
 
-  <!-- include robotiq gripper-->
-  <!-- <xacro:include filename="$(find neo_simulation2)/components/arm/robotiq_gripper.urdf.xacro"/> -->
+  </xacro:if>
 
 </robot>


### PR DESCRIPTION
rox_bringup
- [x] Added `robotiq` grippers support
- [x] Added `gripper`, `robot_ip`, and `controllers_file` launch args to `bringup_launch.py`
- [x] Added missing `scanner_type` arg in `bringup_sim`
- [x] Added `realsense d435` to bringup launch file
- [x] Tested changes in both simulation and mock HW

rox_description
- [x] Updated URDF and args for gripper and `ros2_control` support
