### PR TITLE
Added back gripper and updated to parallel_gripper_action_controller

### DIFF
--- a/rox_bringup/configs/ur/simulation_controllers.yaml
+++ b/rox_bringup/configs/ur/simulation_controllers.yaml
@@ -28,10 +28,10 @@ controller_manager:
       type: position_controllers/JointGroupPositionController
 
     robotiq_2f_140_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     robotiq_2f_85_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
 speed_scaling_state_broadcaster:
   ros__parameters:

--- a/rox_bringup/launch/bringup_sim_launch.py
+++ b/rox_bringup/launch/bringup_sim_launch.py
@@ -23,7 +23,7 @@ def execution_stage(context: LaunchContext,
                     d435_enable,
                     scanner_type,
                     ur_dc,
-                    # gripper_type,
+                    gripper_type,
                     headless_sim,
                     use_wall_time):
 
@@ -31,7 +31,7 @@ def execution_stage(context: LaunchContext,
 
     rox_typ = str(rox_type.perform(context))
     arm_typ = str(arm_type.perform(context))
-    # gripper_typ = str(gripper_type.perform(context))
+    gripper_typ = str(gripper_type.perform(context))
     scanner_typ = str(scanner_type.perform(context))
     d435 = str(d435_enable.perform(context))
     imu = str(imu_enable.perform(context))
@@ -43,7 +43,7 @@ def execution_stage(context: LaunchContext,
     default_world_path = os.path.join(get_package_share_directory('neo_gz_worlds'), 'worlds', 'neo_workshop.sdf')
     bridge_config_file = os.path.join(get_package_share_directory('rox_bringup'), 'configs/gz_bridge', 'gz_bridge_config.yaml')
 
-    # include_gripper_ros2_control = "false"
+    include_gripper_ros2_control = "false"
     include_arm_ros2_control = "false"
 
     if (rox_typ == "diff" or rox_typ == "trike"):
@@ -76,7 +76,7 @@ def execution_stage(context: LaunchContext,
     # Simulation Controllers for the arm
     arm_manufacturer = None
     initial_joint_controller_name = "joint_trajectory_controller"
-    # initial_gripper_controller_name = ""
+    initial_gripper_controller_name = ""
     if arm_typ:
         include_arm_ros2_control = "true"
         if arm_typ in ['ec66', 'cs66']:
@@ -102,16 +102,16 @@ def execution_stage(context: LaunchContext,
         )
         launch_actions.extend(shutdown_handler)
 
-        # if gripper_typ:
-        #     include_gripper_ros2_control = "true"
-        #     gripper_category = None
-        #     if gripper_typ == 'epick':
-        #         gripper_category = 'epick'
-        #         initial_gripper_controller_name = 'epick_controller'
-        #     elif gripper_typ in ['2f_140', '2f_85']:
-        #         gripper_category = 'robotiq'
-        #         initial_gripper_controller_name = f'robotiq_{gripper_typ}_gripper_controller'
-        #     include_gripper_ros2_control = "true"
+        if gripper_typ:
+            include_gripper_ros2_control = "true"
+            gripper_category = None
+            if gripper_typ == 'epick':
+                gripper_category = 'epick'
+                initial_gripper_controller_name = 'epick_controller'
+            elif gripper_typ in ['2f_140', '2f_85']:
+                gripper_category = 'robotiq'
+                initial_gripper_controller_name = f'robotiq_{gripper_typ}_gripper_controller'
+            include_gripper_ros2_control = "true"
 
     else:
         simulation_controllers = ""
@@ -125,12 +125,12 @@ def execution_stage(context: LaunchContext,
         " ", 'use_d435:=', d435,
         " ", 'scanner_type:=', scanner_typ,
         " ", 'arm_type:=', arm_typ,
-        # " ", 'gripper_type:=', gripper_typ,
+        " ", 'gripper_type:=', gripper_typ,
         " ", 'use_ur_dc:=', use_ur_dc,
         " ", 'force_abs_paths:=', "true",
         " ", 'simulation_controllers:=', simulation_controllers,
         " ", 'include_arm_ros2_control:=', include_arm_ros2_control,
-        # " ", 'include_gripper_ros2_control:=', include_gripper_ros2_control
+        " ", 'include_gripper_ros2_control:=', include_gripper_ros2_control
     ]
 
     start_robot_state_publisher_cmd = Node(
@@ -173,11 +173,11 @@ def execution_stage(context: LaunchContext,
         arguments=[initial_joint_controller_name, "-c", "/controller_manager"],
     )
 
-    # robotiq_gripper_controller_spawner = Node(
-    #     package="controller_manager",
-    #     executable="spawner",
-    #     arguments=[initial_gripper_controller_name, "-c", "/controller_manager"]
-    # )
+    robotiq_gripper_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[initial_gripper_controller_name, "-c", "/controller_manager"]
+    )
 
     # Relaying lidar data to /scan topic
     relay_topic_lidar1 = Node(
@@ -215,10 +215,10 @@ def execution_stage(context: LaunchContext,
         elif arm_typ == 'ur5' or arm_typ == 'ur10' or arm_typ == 'ur5e' or arm_typ == 'ur10e':
             env_var_value += ':' + os.path.dirname(get_package_share_directory('ur_description'))
         # Set environment variable for gripper description packages
-        # if gripper_typ == 'epick':
-        #     env_var_value += ':' + os.path.dirname(get_package_share_directory('epick_description'))
-        # else:
-        #     env_var_value += ':' + os.path.dirname(get_package_share_directory('robotiq_description'))
+        if gripper_typ == 'epick':
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('epick_description'))
+        else:
+            env_var_value += ':' + os.path.dirname(get_package_share_directory('robotiq_description'))
             
     set_env_vars_resources = AppendEnvironmentVariable('GZ_SIM_RESOURCE_PATH', env_var_value)
 
@@ -234,8 +234,8 @@ def execution_stage(context: LaunchContext,
     if arm_typ != '':
         launch_actions.append(joint_state_broadcaster_spawner)
         launch_actions.append(initial_joint_controller_spawner_started)
-        # if gripper_typ == '2f_140' or gripper_typ == '2f_85':
-        #     launch_actions.append(robotiq_gripper_controller_spawner)
+        if gripper_typ == '2f_140' or gripper_typ == '2f_85':
+            launch_actions.append(robotiq_gripper_controller_spawner)
 
     return launch_actions
 
@@ -299,7 +299,7 @@ def generate_launch_description():
             LaunchConfiguration('d435_enable'),
             LaunchConfiguration('scanner_type'),
             LaunchConfiguration('use_ur_dc'),
-            # LaunchConfiguration('gripper_type'),
+            LaunchConfiguration('gripper_type'),
             LaunchConfiguration('headless_simulation'),
             LaunchConfiguration('use_wall_time')
             ])
@@ -311,7 +311,7 @@ def generate_launch_description():
         declare_arm_type_cmd,
         declare_rox_type_cmd,
         declare_ur_pwr_variant_cmd,
-        # declare_gripper_type_cmd,
+        declare_gripper_type_cmd,
         declare_headless_sim_cmd,
         declare_use_wall_time_cmd,
         opq_function


### PR DESCRIPTION
- the support for position_controller has been deprecated from Jazzy and above. (https://control.ros.org/jazzy/doc/ros2_controllers/gripper_controllers/doc/userdoc.html#gripper-action-controller)
- the gripper controller was tested in gz sim in both Jazzy and Rolling. It works fine in Jazzy. But, there are issues with rolling wherein the mimicking joints don't properly close for the grippers (this might be due to some breaking changes in rolling)
- this has to be tested for Kilted

NOTE: the changes from this PR (https://github.com/neobotix/ros2_robotiq_gripper/pull/4) need to be cherry picked in order for the following to work
- the following commands were used for testing it

```
ros2 launch rox_bringup bringup_sim_launch.py arm_type:=ur10 gripper_type:=2f_140
ros2 action send_goal /robotiq_2f_140_gripper_controller/gripper_cmd   control_msgs/action/ParallelGripperCommand "{command: {position: [0.5]}}"
ros2 action send_goal /robotiq_2f_140_gripper_controller/gripper_cmd   control_msgs/action/ParallelGripperCommand "{command: {position: [0.1]}}"

```
Please change 2f_140 to 2f_85 in the commands above for changing the gripper